### PR TITLE
Allow changing the play/pause icon with custom text & finer control of styling via new classes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,19 @@ It follows the same rules as pomodoro: 4 cycles of work and short breaks, follow
 
 # How to use
 
-* compile & install binary
+- compile & install binary
+
 ```bash
 git clone git@github.com:Andeskjerf/waybar-module-pomodoro.git
 cd waybar-module-pomodoro
 cargo build --release
 ```
+
 You can find the binary in `workingDir/target/release/waybar-module-pomodoro`.
 
 Place the file in a folder you have in your $PATH. E.g `/home/user/.local/bin`
-  
-* add to `~/.config/waybar/config`
+
+- add to `~/.config/waybar/config`
 
 ```json
 "custom/pomodoro": {
@@ -55,4 +57,15 @@ usage: waybar-module-pomodoro [options] [operation]
         start                       Start the timer
         pause                       Pause the timer
         reset                       Reset timer to initial state
+```
+
+## CSS Styling
+
+Valid classes:
+
+```
+""          -   timer has not yet been started
+"pause"     -   timer has been paused
+"work"      -   timer is currently in a work cycle
+"break"     -   timer is currently in a break cycle, either a short or long one
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ usage: waybar-module-pomodoro [options] [operation]
         -w, --work <value>          Sets how long a work cycle is, in minutes. default: 25
         -s, --shortbreak <value>    Sets how long a short break is, in minutes. default: 5
         -l, --longbreak <value>     Sets how long a long break is, in minutes. default: 15
+        -p, --play <value>          Sets custom play icon/text. default: ▶
+        -a, --pause <value>         Sets custom pause icon/text. default: ⏸
         --no-icons                  Disable the pause/play icon
     operations:
         toggle                      Toggles the timer

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,12 @@
-use crate::{LONG_BREAK_TIME, MINUTE, SHORT_BREAK_TIME, WORK_TIME};
+use crate::{LONG_BREAK_TIME, MINUTE, PAUSE_ICON, PLAY_ICON, SHORT_BREAK_TIME, WORK_TIME};
 
 pub struct Config {
     pub work_time: u16,
     pub short_break: u16,
     pub long_break: u16,
     pub no_icons: bool,
+    pub play_icon: String,
+    pub pause_icon: String,
     pub binary_name: String,
 }
 
@@ -16,20 +18,33 @@ impl Config {
         let mut short_break: u16 = SHORT_BREAK_TIME;
         let mut long_break: u16 = LONG_BREAK_TIME;
         let mut no_icons = false;
+        let mut play_icon = PLAY_ICON.to_string();
+        let mut pause_icon = PAUSE_ICON.to_string();
 
         let binary_path = options.first().unwrap();
         let binary_name = binary_path.split('/').last().unwrap().to_string();
 
         options.iter().for_each(|opt| match opt.as_str() {
             "-w" | "--work" => {
-                work_time = get_config_value(&options, vec!["-w", "--work"]) * MINUTE
+                work_time = get_config_value(&options, vec!["-w", "--work"])
+                    .parse::<u16>()
+                    .expect("value is not a number")
+                    * MINUTE
             }
             "-s" | "--shortbreak" => {
-                short_break = get_config_value(&options, vec!["-s", "--shortbreak"]) * MINUTE
+                short_break = get_config_value(&options, vec!["-s", "--shortbreak"])
+                    .parse::<u16>()
+                    .expect("value is not a number")
+                    * MINUTE
             }
             "-l" | "--longbreak" => {
-                long_break = get_config_value(&options, vec!["-l", "--longbreak"]) * MINUTE
+                long_break = get_config_value(&options, vec!["-l", "--longbreak"])
+                    .parse::<u16>()
+                    .expect("value is not a number")
+                    * MINUTE
             }
+            "-p" | "--play" => play_icon = get_config_value(&options, vec!["-p", "--play"]),
+            "-a" | "--pause" => pause_icon = get_config_value(&options, vec!["-a", "--pause"]),
             "--no-icons" => no_icons = true,
             _ => (),
         });
@@ -39,18 +54,18 @@ impl Config {
             short_break,
             long_break,
             no_icons,
+            play_icon,
+            pause_icon,
             binary_name,
         }
     }
 }
 
-fn get_config_value(options: &[String], keys: Vec<&str>) -> u16 {
+fn get_config_value(options: &[String], keys: Vec<&str>) -> String {
     let index = options
         .iter()
         .position(|x| keys.contains(&x.as_str()))
         .expect("option specified but no value followed");
 
-    options[index + 1]
-        .parse::<u16>()
-        .expect("value is not a number")
+    options[index + 1].to_owned()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,8 +329,8 @@ fn print_help() {
         -w, --work <value>          Sets how long a work cycle is, in minutes. default: {}
         -s, --shortbreak <value>    Sets how long a short break is, in minutes. default: {}
         -l, --longbreak <value>     Sets how long a long break is, in minutes. default: {}
-        -p, --play <value>          Sets custom play icon. default: {}
-        -a, --pause <value>         Sets custom pause icon. default: {}
+        -p, --play <value>          Sets custom play icon/text. default: {}
+        -a, --pause <value>         Sets custom pause icon/text. default: {}
         --no-icons                  Disable the pause/play icon
     operations:
         toggle                      Toggles the timer

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,8 @@ const MAX_ITERATIONS: u8 = 4;
 const WORK_TIME: u16 = 25 * MINUTE;
 const SHORT_BREAK_TIME: u16 = 5 * MINUTE;
 const LONG_BREAK_TIME: u16 = 15 * MINUTE;
+const PLAY_ICON: &str = "▶";
+const PAUSE_ICON: &str = "⏸";
 
 enum CycleType {
     Work,
@@ -167,12 +169,12 @@ fn handle_client(rx: Receiver<String>, socket_path: String, config: Config) {
         let value = format_time(state.elapsed_time, state.get_current_time());
         let value_prefix = if !config.no_icons {
             if state.running {
-                "⏸ "
+                format!("{} ", config.pause_icon)
             } else {
-                "▶ "
+                format!("{} ", config.play_icon)
             }
         } else {
-            ""
+            "".to_owned()
         };
         let tooltip = format!(
             "{} pomodoro{} completed this session",
@@ -327,6 +329,8 @@ fn print_help() {
         -w, --work <value>          Sets how long a work cycle is, in minutes. default: {}
         -s, --shortbreak <value>    Sets how long a short break is, in minutes. default: {}
         -l, --longbreak <value>     Sets how long a long break is, in minutes. default: {}
+        -p, --play <value>          Sets custom play icon. default: {}
+        -a, --pause <value>         Sets custom pause icon. default: {}
         --no-icons                  Disable the pause/play icon
     operations:
         toggle                      Toggles the timer
@@ -335,6 +339,8 @@ fn print_help() {
         reset                       Reset timer to initial state"#,
         WORK_TIME / MINUTE,
         SHORT_BREAK_TIME / MINUTE,
-        LONG_BREAK_TIME / MINUTE
+        LONG_BREAK_TIME / MINUTE,
+        PLAY_ICON,
+        PAUSE_ICON,
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ impl State {
     fn reset(&mut self) {
         self.current_index = 0;
         self.elapsed_time = 0;
+        self.elapsed_millis = 0;
         self.iterations = 0;
         self.running = false;
     }
@@ -134,6 +135,33 @@ fn print_message(value: String, tooltip: &str, class: &str) {
     );
 }
 
+fn get_class(state: &State) -> String {
+    // timer hasn't been started yet
+    if state.elapsed_millis == 0
+        && state.elapsed_time == 0
+        && state.iterations == 0
+        && state.session_completed == 0
+    {
+        "".to_owned()
+    }
+    // timer has been paused
+    else if !state.running {
+        "pause".to_owned()
+    }
+    // currently doing some work
+    else if state.current_index == 0 {
+        "work".to_owned()
+    }
+    // currently a break
+    else if state.current_index != 0 {
+        "break".to_owned()
+    }
+    // this shouldn't happen but we still need to handle it
+    else {
+        panic!("invalid condition occurred while trying to set class!")
+    }
+}
+
 fn handle_client(rx: Receiver<String>, socket_path: String, config: Config) {
     let mut state = State::new(config.work_time, config.short_break, config.long_break);
 
@@ -185,11 +213,7 @@ fn handle_client(rx: Receiver<String>, socket_path: String, config: Config) {
                 ""
             }
         );
-        let class = if state.current_index == 0 {
-            "work"
-        } else {
-            "break"
-        };
+        let class = &get_class(&state);
         state.update_state();
         print_message(
             value_prefix.to_string() + value.clone().as_str(),


### PR DESCRIPTION
Add new arguments,

```
        -p, --play <value>          Sets custom play icon/text. default: {}
        -a, --pause <value>         Sets custom pause icon/text. default: {}
```

which allows the user to set custom text for both play and pause.

Add new possible classes, "" and "pause".