### PR TITLE
Add flags to auto progress the timer when either a break or work has started

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ usage: waybar-module-pomodoro [options] [operation]
 
         --no-icons                  Disable the pause/play icon
 
+        --autow                     Starts a work cycle automatically after a break
+        --autob                     Starts a break cycle automatically after work
+
     operations:
         toggle                      Toggles the timer
         start                       Start the timer

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub pause_icon: String,
     pub work_icon: String,
     pub break_icon: String,
+    pub autow: bool,
+    pub autob: bool,
     pub binary_name: String,
 }
 
@@ -27,6 +29,8 @@ impl Config {
         let mut pause_icon = PAUSE_ICON.to_string();
         let mut work_icon = WORK_ICON.to_string();
         let mut break_icon = BREAK_ICON.to_string();
+        let mut autow = false;
+        let mut autob = false;
 
         let binary_path = options.first().unwrap();
         let binary_name = binary_path.split('/').last().unwrap().to_string();
@@ -58,6 +62,8 @@ impl Config {
             "-b" | "--break-icon" => {
                 break_icon = get_config_value(&options, vec!["-b", "--break-icon"])
             }
+            "--autow" => autow = true,
+            "--autob" => autob = true,
             "--no-icons" => no_icons = true,
             _ => (),
         });
@@ -71,6 +77,8 @@ impl Config {
             pause_icon,
             work_icon,
             break_icon,
+            autow,
+            autob,
             binary_name,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ impl State {
         self.current_index != 0
     }
 
-    fn update_state(&mut self) {
+    fn update_state(&mut self, config: &Config) {
         if (self.times[self.current_index] - self.elapsed_time) == 0 {
             // if we're on the third iteration and first work, then we want a long break
             if self.current_index == 0 && self.iterations == MAX_ITERATIONS - 1 {
@@ -96,8 +96,10 @@ impl State {
             }
 
             self.elapsed_time = 0;
-            // stop the timer and wait for user to start next cycle
-            self.running = false;
+
+            // if the user has passed either auto flag, we want to keep ticking the timer
+            // NOTE: the is_break() seems to be flipped..?
+            self.running = (config.autob && self.is_break()) || (config.autow && !self.is_break());
         }
     }
 
@@ -225,7 +227,7 @@ fn handle_client(rx: Receiver<String>, socket_path: String, config: Config) {
         } else {
             &config.break_icon
         };
-        state.update_state();
+        state.update_state(&config);
         print_message(
             format!("{} {} {}", value_prefix, value, cycle_icon),
             tooltip.as_str(),
@@ -371,6 +373,9 @@ fn print_help() {
         -b, --break-icon <value>    Sets custom break icon/text. default: {}
 
         --no-icons                  Disable the pause/play icon
+
+        --autow                     Starts a work cycle automatically after a break
+        --autob                     Starts a break cycle automatically after work
 
     operations:
         toggle                      Toggles the timer


### PR DESCRIPTION
Add new flags,
```
        --autow                     Starts a work cycle automatically after a break
        --autob                     Starts a break cycle automatically after work
```

Closes https://github.com/Andeskjerf/waybar-module-pomodoro/issues/6