### PR TITLE
If connecting to a socket fails, don't exit the program

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -362,7 +362,10 @@ fn main() -> std::io::Result<()> {
     }
 
     for socket in sockets {
-        send_message_socket(&socket, &operation[0])?;
+        match send_message_socket(&socket, &operation[0]) {
+            Ok(_) => {}
+            Err(_) => println!("warn: failed to connect to {}", socket),
+        };
     }
     Ok(())
 }


### PR DESCRIPTION
An attempt to fix https://github.com/Andeskjerf/waybar-module-pomodoro/issues/11. Still doesn't resolve the left over sockets that doesn't disappear when logging out, but should hopefully resolve the issue where it breaks all other sockets.

Closes https://github.com/Andeskjerf/waybar-module-pomodoro/issues/11