### PR TITLE
Ver: 0.1.2 Added configurable auto-restore feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waybar-module-pomodoro"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,3 +8,5 @@ edition = "2021"
 [dependencies]
 notify-rust = "4.11.0"
 signal-hook = "0.3.17"
+serde = { version = "1.0.104", features = ["derive"] }
+serde_json = "1.0.48"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ usage: waybar-module-pomodoro [options] [operation]
 
         --autow                     Starts a work cycle automatically after a break
         --autob                     Starts a break cycle automatically after work
+        --autor                     Restore timer to prior-state (even after shutdown)
 
     operations:
         toggle                      Toggles the timer

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ usage: waybar-module-pomodoro [options] [operation]
 
         --autow                     Starts a work cycle automatically after a break
         --autob                     Starts a break cycle automatically after work
-        --autor                     Restore timer to prior-state (even after shutdown)
+        --persist                   Persist timer state between sessions
 
     operations:
         toggle                      Toggles the timer

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -25,12 +25,9 @@ pub(crate) fn restore(state: &mut State, config: &Config) -> io::Result<()> {
     let output_name = format!("{}-{}", MODULE, VERSION);
     filepath.push(output_name);
 
-    let file = File::open(filepath)
-        .expect("Cache file should open");
-    let json: serde_json::Value = serde_json::from_reader(file)
-        .expect("Cache file should be proper JSON");
-
-    let restored: State = serde_json::from_value(json).unwrap();
+    let file = File::open(filepath)?;
+    let json: serde_json::Value = serde_json::from_reader(file)?;
+    let restored: State = serde_json::from_value(json)?;
 
     if match_timers(&config, &restored.times) {
         state.current_index = restored.current_index;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,89 @@
+use crate::Config;
+use crate::State;
+use std::{
+    env,
+    fs::File,
+    path::{Path, PathBuf},
+    io::{self, Write},
+};
+
+const MODULE: &str = env!("CARGO_PKG_NAME");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub(crate) fn store(state: &State) -> io::Result<()> {
+    let mut filepath = cache_dir()?;
+    let output_name = format!("{}-{}", MODULE, VERSION);
+    filepath.push(output_name);
+
+    let data = serde_json::to_string(&state)
+        .expect("Not a serializable type");
+    File::create(filepath)?.write_all(data.as_bytes())
+}
+
+pub(crate) fn restore(state: &mut State, config: &Config) -> io::Result<()> {
+    let mut filepath = cache_dir()?;
+    let output_name = format!("{}-{}", MODULE, VERSION);
+    filepath.push(output_name);
+
+    let file = File::open(filepath)
+        .expect("Cache file should open");
+    let json: serde_json::Value = serde_json::from_reader(file)
+        .expect("Cache file should be proper JSON");
+
+    let restored: State = serde_json::from_value(json).unwrap();
+
+    if match_timers(&config, &restored.times) {
+        state.current_index = restored.current_index;
+        state.elapsed_millis = restored.elapsed_millis;
+        state.elapsed_time = restored.elapsed_time;
+        state.times = restored.times;
+        state.iterations = restored.iterations;
+        state.session_completed = restored.session_completed;
+    }
+
+    Ok(())
+}
+
+fn match_timers(config: &Config, times: &[u16; 3]) -> bool {
+    let work_time: u16 = times[0];
+    let short_break: u16 = times[1];
+    let long_break: u16 = times[2];
+
+    if config.work_time != work_time
+    || config.short_break != short_break
+    || config.long_break != long_break {
+        return false;
+    }
+
+    true
+}
+
+fn create_dir(p: &Path) -> io::Result<()> {
+    if !p.is_dir() {
+        std::fs::create_dir(p)
+    } else {
+        Ok(())
+    }
+}
+
+fn cache_dir() -> io::Result<PathBuf> {
+
+    if let Ok(path) = env::var("XDG_CACHE_HOME") {
+        let mut path: PathBuf = path.into();
+        path.push(MODULE);
+        create_dir(&path)?;
+        Ok(path)
+    } else if let Ok(path) = env::var("HOME") {
+        let mut path: PathBuf = path.into();
+        path.push(".cache");
+        path.push(MODULE);
+        create_dir(&path)?;
+        Ok(path)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "failed to read both $XDG_CACHE_HOME and $HOME environment variables".to_string(),
+        ))
+    }
+}
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub break_icon: String,
     pub autow: bool,
     pub autob: bool,
+    pub autor: bool,
     pub binary_name: String,
 }
 
@@ -33,6 +34,7 @@ impl Config {
         let mut break_icon = BREAK_ICON.to_string();
         let mut autow = false;
         let mut autob = false;
+        let mut autor = false;
 
         let binary_path = options.first().unwrap();
         let binary_name = binary_path.split('/').last().unwrap().to_string();
@@ -66,6 +68,7 @@ impl Config {
             }
             "--autow" => autow = true,
             "--autob" => autob = true,
+            "--autor" => autor = true,
             "--no-icons" => no_icons = true,
             "--no-work-icons" => no_work_icons = true,
             _ => (),
@@ -83,6 +86,7 @@ impl Config {
             break_icon,
             autow,
             autob,
+            autor,
             binary_name,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,7 +68,7 @@ impl Config {
             }
             "--autow" => autow = true,
             "--autob" => autob = true,
-            "--persist" => autor = true,
+            "--persist" => persist = true,
             "--no-icons" => no_icons = true,
             "--no-work-icons" => no_work_icons = true,
             _ => (),

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     pub break_icon: String,
     pub autow: bool,
     pub autob: bool,
-    pub autor: bool,
+    pub persist: bool,
     pub binary_name: String,
 }
 
@@ -34,7 +34,7 @@ impl Config {
         let mut break_icon = BREAK_ICON.to_string();
         let mut autow = false;
         let mut autob = false;
-        let mut autor = false;
+        let mut persist = false;
 
         let binary_path = options.first().unwrap();
         let binary_name = binary_path.split('/').last().unwrap().to_string();
@@ -68,7 +68,7 @@ impl Config {
             }
             "--autow" => autow = true,
             "--autob" => autob = true,
-            "--autor" => autor = true,
+            "--persist" => autor = true,
             "--no-icons" => no_icons = true,
             "--no-work-icons" => no_work_icons = true,
             _ => (),
@@ -86,7 +86,7 @@ impl Config {
             break_icon,
             autow,
             autob,
-            autor,
+            persist,
             binary_name,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ fn handle_client(rx: Receiver<String>, socket_path: String, config: Config) {
         socket_nr,
     );
 
-    if config.autor {
+    if config.persist {
         let _ = cache::restore(&mut state, &config);
     }
 
@@ -246,7 +246,7 @@ fn handle_client(rx: Receiver<String>, socket_path: String, config: Config) {
             state.increment_time();
         }
 
-        if config.autor {
+        if config.persist {
             let _ = cache::store(&state);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,7 +394,7 @@ fn print_help() {
 
         --autow                     Starts a work cycle automatically after a break
         --autob                     Starts a break cycle automatically after work
-        --autor                     Restore timer to prior-state (even after shutdown)
+        --persist                   Persist timer state between sessions
 
     operations:
         toggle                      Toggles the timer


### PR DESCRIPTION
First of all thanks for this awesome module!

This PR handles feature-request: #16 

- This feature allows to resume pomodoro timer from prior-state (even after shutdown)
- Auto restore feature can be enabled with --autor flag
- Added necessary checks for fool-proof design (like match-timer check)
- Ensured usual work-flow by making sure we don't update state.running flag
- socket_nr is also not updated because we need to work with new socket_nr
- Updated README
- Updated help_message 

NOTE:
- This might come in handy if someone accidentally closes waybar and now wants to resume his timer.
- Also, if --autor flag is absent waybar-module-pomodoro works as if this feature doesn't even exist

Hoping for a positive response!!
In case you are not interested, feel also free to close this PR :)

Cheers!