### PR TITLE
Add new operations to change timer values while running

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waybar-module-pomodoro"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 notify-rust = "4.11.0"
+regex = "1.11.1"
 signal-hook = "0.3.17"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ usage: waybar-module-pomodoro [options] [operation]
         start                       Start the timer
         stop                        Stop the timer
         reset                       Reset timer to initial state
+
+        set-work <value>            Set new work time
+        set-short <value>           Set new short break time
+        set-long <value>            Set new long break time
 ```
 
 ## CSS Styling

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -29,7 +29,7 @@ pub(crate) fn restore(state: &mut State, config: &Config) -> io::Result<()> {
     let json: serde_json::Value = serde_json::from_reader(file)?;
     let restored: State = serde_json::from_value(json)?;
 
-    if match_timers(&config, &restored.times) {
+    if match_timers(config, &restored.times) {
         state.current_index = restored.current_index;
         state.elapsed_millis = restored.elapsed_millis;
         state.elapsed_time = restored.elapsed_time;

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,26 +41,29 @@ impl Config {
         let binary_name = binary_path.split('/').last().unwrap().to_string();
 
         for opt in options.iter() {
-            let val = get_config_value(&options, vec![opt]);
-            if val.is_none() {
-                continue;
-            }
-
-            let val = val.unwrap().clone();
             match opt.as_str() {
                 "-w" | "--work" => {
-                    work_time = val.parse::<u16>().expect("value is not a number") * MINUTE
+                    work_time = get_config_value_except(&options, opt)
+                        .parse::<u16>()
+                        .expect("value is not a number")
+                        * MINUTE
                 }
                 "-s" | "--shortbreak" => {
-                    short_break = val.parse::<u16>().expect("value is not a number") * MINUTE
+                    short_break = get_config_value_except(&options, opt)
+                        .parse::<u16>()
+                        .expect("value is not a number")
+                        * MINUTE
                 }
                 "-l" | "--longbreak" => {
-                    long_break = val.parse::<u16>().expect("value is not a number") * MINUTE
+                    long_break = get_config_value_except(&options, opt)
+                        .parse::<u16>()
+                        .expect("value is not a number")
+                        * MINUTE
                 }
-                "-p" | "--play" => play_icon = val,
-                "-a" | "--pause" => pause_icon = val,
-                "-o" | "--work-icon" => work_icon = val,
-                "-b" | "--break-icon" => break_icon = val,
+                "-p" | "--play" => play_icon = get_config_value_except(&options, opt).clone(),
+                "-a" | "--pause" => pause_icon = get_config_value_except(&options, opt),
+                "-o" | "--work-icon" => work_icon = get_config_value_except(&options, opt),
+                "-b" | "--break-icon" => break_icon = get_config_value_except(&options, opt),
                 "--autow" => autow = true,
                 "--autob" => autob = true,
                 "--persist" => persist = true,
@@ -110,6 +113,12 @@ impl Config {
             &self.break_icon
         }
     }
+}
+
+fn get_config_value_except(options: &[String], opt: &str) -> String {
+    get_config_value(options, vec![opt])
+        .unwrap_or_else(|| panic!("err: {opt} specified but no value was provided"))
+        .clone()
 }
 
 pub fn get_config_value<'a>(options: &'a [String], keys: Vec<&'a str>) -> Option<&'a String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BREAK_ICON, LONG_BREAK_TIME, MINUTE, PAUSE_ICON, PLAY_ICON, SHORT_BREAK_TIME, WORK_ICON,
-    WORK_TIME,
+    models::message::Message, BREAK_ICON, LONG_BREAK_TIME, MINUTE, PAUSE_ICON, PLAY_ICON,
+    SHORT_BREAK_TIME, WORK_ICON, WORK_TIME,
 };
 
 pub const OPERATIONS: [&str; 4] = ["toggle", "start", "stop", "reset"];
@@ -41,7 +41,6 @@ impl Config {
         for opt in options.iter() {
             let val = get_config_value(&options, vec![opt]);
             if val.is_none() {
-                println!("warn: unable to parse `{opt}`! no value found");
                 continue;
             }
 
@@ -116,8 +115,8 @@ pub fn get_config_value<'a>(options: &'a [String], keys: Vec<&'a str>) -> Option
     }
 }
 
-pub fn parse_set_operations(args: Vec<String>) -> Vec<(String, u32)> {
-    let mut set_operation: Vec<(String, u32)> = vec![];
+pub fn parse_set_operations(args: Vec<String>) -> Vec<Message> {
+    let mut set_operation: Vec<Message> = vec![];
     for elem in SET_OPERATIONS {
         if !args.contains(&elem.to_string()) {
             continue;
@@ -125,14 +124,13 @@ pub fn parse_set_operations(args: Vec<String>) -> Vec<(String, u32)> {
 
         let val = get_config_value(&args, vec![elem]);
         if val.is_none() {
-            println!("warn: unable to parse `{elem}`! no value found");
             continue;
         }
 
         let val = val.unwrap();
         if let Ok(val) = val.parse::<i32>() {
             if val > 0 {
-                set_operation.push((elem.to_string(), val as u32));
+                set_operation.push(Message::new(elem, val));
             } else {
                 println!("{elem}: value must be higher than 0, ignoring");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,6 +320,7 @@ fn process_signals(socket_path: String) {
 fn main() -> std::io::Result<()> {
     // valid operations
     let operations = ["toggle", "start", "stop", "reset"];
+    let set_operations = ["set-work", "set-short", "set-long"];
 
     let options = env::args().collect::<Vec<String>>();
     if options.contains(&"--help".to_string()) || options.contains(&"-h".to_string()) {
@@ -388,7 +389,11 @@ fn print_help() {
         toggle                      Toggles the timer
         start                       Start the timer
         stop                        Stop the timer
-        reset                       Reset timer to initial state"#,
+        reset                       Reset timer to initial state
+
+        set-work <value>            Set new work time
+        set-short <value>           Set new short break time
+        set-long <value>            Set new long break time"#,
         WORK_TIME / MINUTE,
         SHORT_BREAK_TIME / MINUTE,
         LONG_BREAK_TIME / MINUTE,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use config::Config;
+use config::{parse_set_operations, Config, OPERATIONS};
+use models::message::Message;
 use notify_rust::Notification;
 use signal_hook::{
     consts::{SIGHUP, SIGINT, SIGTERM},
@@ -15,6 +16,7 @@ use std::{
 };
 
 mod config;
+mod models;
 mod utils;
 
 const SLEEP_TIME: u16 = 100;
@@ -318,10 +320,6 @@ fn process_signals(socket_path: String) {
 }
 
 fn main() -> std::io::Result<()> {
-    // valid operations
-    let operations = ["toggle", "start", "stop", "reset"];
-    let set_operations = ["set-work", "set-short", "set-long"];
-
     let options = env::args().collect::<Vec<String>>();
     if options.contains(&"--help".to_string()) || options.contains(&"-h".to_string()) {
         print_help();
@@ -345,7 +343,7 @@ fn main() -> std::io::Result<()> {
     );
 
     let operation = env::args()
-        .filter(|x| operations.contains(&x.as_str()))
+        .filter(|x| OPERATIONS.contains(&x.as_str()))
         .collect::<Vec<String>>();
 
     if operation.is_empty() {
@@ -361,6 +359,7 @@ fn main() -> std::io::Result<()> {
             Err(_) => println!("warn: failed to connect to {}", socket),
         };
     }
+    let set_operation = parse_set_operations(env::args().collect::<Vec<String>>());
     Ok(())
 }
 

--- a/src/models/message.rs
+++ b/src/models/message.rs
@@ -1,0 +1,34 @@
+use std::num::ParseIntError;
+
+use regex::Regex;
+
+pub struct Message {
+    name: String,
+    value: i32,
+}
+
+impl Message {
+    pub fn new(name: &str, value: i32) -> Self {
+        Self {
+            name: String::from(name),
+            value,
+        }
+    }
+
+    pub fn decode(input: &str) -> Result<Self, ParseIntError> {
+        let re = Regex::new(r"\[(.*?)\;(.*?)\]").unwrap();
+
+        let mut name = String::new();
+        let mut value = -1;
+        for (_, [_name, _value]) in re.captures_iter(input).map(|c| c.extract()) {
+            name = String::from(_name);
+            value = _value.parse()?;
+        }
+
+        Ok(Self { name, value })
+    }
+
+    pub fn encode(&self) -> String {
+        format!("[{};{}]", self.name, self.value)
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod message;


### PR DESCRIPTION
Previously, you had to restart the process and provide new values, which isn't very flexible considering that normally means restarting Waybar.

Now you can instead set them just like you start and stop the timer.

```
set-work <value>            Set new work time
set-short <value>           Set new short break time
set-long <value>            Set new long break time
```
Invoked like,
```bash
waybar-module-pomodoro set-work 20
```

Closes #18 