### PR TITLE
Added hour-value in time-format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waybar-module-pomodoro"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/services/server.rs
+++ b/src/services/server.rs
@@ -13,7 +13,7 @@ use crate::{
     models::{config::Config, message::Message},
     utils::{
         self,
-        consts::{MINUTE, SLEEP_DURATION},
+        consts::{MINUTE, HOUR, SLEEP_DURATION},
     },
 };
 
@@ -38,8 +38,15 @@ pub fn send_notification(cycle_type: CycleType) {
 
 fn format_time(elapsed_time: u16, max_time: u16) -> String {
     let time = max_time - elapsed_time;
-    let minute = time / MINUTE;
+
+    let hour = time / HOUR;
+    let minute = (time % HOUR) / MINUTE;
     let second = time % MINUTE;
+
+    if hour > 0 {
+        return format!("{:02}:{:02}:{:02}", hour, minute, second)
+    }
+    
     format!("{:02}:{:02}", minute, second)
 }
 

--- a/src/services/server.rs
+++ b/src/services/server.rs
@@ -13,7 +13,7 @@ use crate::{
     models::{config::Config, message::Message},
     utils::{
         self,
-        consts::{MINUTE, HOUR, SLEEP_DURATION},
+        consts::{HOUR, MINUTE, SLEEP_DURATION},
     },
 };
 
@@ -44,9 +44,9 @@ fn format_time(elapsed_time: u16, max_time: u16) -> String {
     let second = time % MINUTE;
 
     if hour > 0 {
-        return format!("{:02}:{:02}:{:02}", hour, minute, second)
+        return format!("{:02}:{:02}:{:02}", hour, minute, second);
     }
-    
+
     format!("{:02}:{:02}", minute, second)
 }
 

--- a/src/utils/consts.rs
+++ b/src/utils/consts.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 pub const SLEEP_TIME: u16 = 100;
 pub const SLEEP_DURATION: Duration = Duration::from_millis(SLEEP_TIME as u64);
 pub const MINUTE: u16 = 60;
+pub const HOUR: u16 = 60 * MINUTE;
 pub const MAX_ITERATIONS: u8 = 4;
 pub const WORK_TIME: u16 = 25 * MINUTE;
 pub const SHORT_BREAK_TIME: u16 = 5 * MINUTE;


### PR DESCRIPTION
First of all; thanks, for this awesome module! This is really helpful.

I did a little change for time-format:
- to display non-zero hour-value (i.e, only if minute-value exceed 60)
- version: 0.2.1

In case you are not interested, feel also free to close this PR :)
Cheers!